### PR TITLE
Expand StitchingUtils API

### DIFF
--- a/src/main/java/ch/fmi/visiview/VisiViewStitching.java
+++ b/src/main/java/ch/fmi/visiview/VisiViewStitching.java
@@ -61,8 +61,10 @@ import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
+import ch.fmi.stitching.StitchingUtils;
+
 @Plugin(type = Command.class, headless = true,
-	menuPath = "FMI>VisiView Data>Stitch Dataset (beta)",
+	menuPath = "FMI>VisiView Data>Stitch Dataset (default)",
 	initializer = "initializeDialog")
 public class VisiViewStitching extends DynamicCommand {
 


### PR DESCRIPTION
- move `StitchingUtils` to package `ch.fmi.stitching`
- additional method signatures for `computeStitching()` to cover more use cases
- relax `positions` parameter from `ArrayList` to `List`
- set `params.regThreshold = 0.7` by default, to be more strict when finding tile correspondences